### PR TITLE
Fix accidental globals and Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
-var join = require('path').join;
-    fs = require('fs'),
-    exists = fs.existsSync,
-    read = fs.readFileSync;
+var pathModule = require('path'),
+    fs = require('fs');
 
 var find = function(path, filename) {
-	if (!path.length) {
+	if (!path) {
 		return null;
 	}
 
-	var filepath = join(path, filename);
-	if (exists(filepath)) {
-		return read(filepath).toString();
+	var filepath = pathModule.join(path, filename);
+	if (fs.existsSync(filepath)) {
+		return fs.readFileSync(filepath).toString();
 	}
 
-	return find(path.slice(0, path.lastIndexOf('/')), filename);
+	var nextpath = pathModule.dirname(path);
+	return find(nextpath !== path ? nextpath : '', filename);
 };
 
 module.exports = find;


### PR DESCRIPTION
The code had 2 issues:
- The first line ended with semicolon instead of comma, so the declarations on line 2-4 where actually globals.
- The performance on Windows was bad because the code used `path.lastIndexOf('/')` to go up one directory, but Windows uses backslash (`'\'`). The code still worked, because slicing with -1 trims the string by one character, but it's really inefficient.

This commit fixes both.
